### PR TITLE
Bug Fix - Missing Info Fix - Case #004

### DIFF
--- a/src/cases/schemas/case-004.ts
+++ b/src/cases/schemas/case-004.ts
@@ -1132,7 +1132,7 @@ export default [
     (55, 55, 'Youve got this wrong. Im not someone who would kill.'),
     (56, 56, 'I was at church that morning. I couldnt kill anyone.'),
     (57, 57, 'This is a huge misunderstanding. I would never kill.'),
-    (58, 58, 'I didn’t kill Leo per se. I was just a middleman.'),
+    (58, 58, 'I didn’t kill Leo per se. I was just a middleman. It was a someone else who killed him, all I know about him is that he drives a Lamborghini.'),
     (59, 59, 'Im innocent of this. I couldnt possibly kill someone.'),
     (60, 60, 'Youre barking up the wrong tree. I wouldnt kill anybody.'),
     (61, 61, 'I have a solid alibi. I didnt kill anyone that day.'),


### PR DESCRIPTION
The Final Confession of "Victor DiMarco" with Person ID = 58, is missing the crucial info of the vehicle detail of the true murderer halting the case's progression.

Even tho the after submission page shows that the clue should have been revealed, it wasn't.
Hence, adding the relevant clue in the Middleman's statement to make sure the user doesn't get stuck.